### PR TITLE
feat: exclude 'Inclusao de Pagamento' transactions from expense calculations

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -3,6 +3,10 @@ import { Transaction } from '../types/Transaction';
 import { CategoryStats } from '../types/Category';
 import { TrendingUp, CreditCard, Calendar, DollarSign } from 'lucide-react';
 
+const isPaymentTransaction = (transaction: Transaction): boolean => {
+  return transaction.descricao.toLowerCase().includes('inclusao de pagamento');
+};
+
 interface DashboardProps {
   transactions: Transaction[];
 }
@@ -31,14 +35,14 @@ export const Dashboard: React.FC<DashboardProps> = ({ transactions }) => {
   };
 
   const stats = useMemo(() => {
-    const totalTransactions = transactions.length;
-    const totalAmount = transactions.reduce((sum, t) => sum + t.valorBRL, 0);
+    const totalTransactions = transactions.filter(t => !isPaymentTransaction(t)).length;
+    const totalAmount = transactions.filter(t => !isPaymentTransaction(t)).reduce((sum, t) => sum + t.valorBRL, 0);
     const avgAmount = totalAmount / totalTransactions || 0;
     
     const categoryStats: CategoryStats[] = [];
     const categoryMap = new Map<string, { count: number; total: number }>();
     
-    transactions.forEach(transaction => {
+    transactions.filter(t => !isPaymentTransaction(t)).forEach(transaction => {
       const category = transaction.categoriaCustom || 'Outros';
       const current = categoryMap.get(category) || { count: 0, total: 0 };
       categoryMap.set(category, {
@@ -59,7 +63,7 @@ export const Dashboard: React.FC<DashboardProps> = ({ transactions }) => {
     categoryStats.sort((a, b) => b.totalBRL - a.totalBRL);
     
     const monthlyData = new Map<string, number>();
-    transactions.forEach(transaction => {
+    transactions.filter(t => !isPaymentTransaction(t)).forEach(transaction => {
       const date = transaction.dataCompra;
       const month = date.substring(3); // MM/YYYY
       const current = monthlyData.get(month) || 0;


### PR DESCRIPTION
# feat: exclude 'Inclusao de Pagamento' transactions from expense calculations

## Summary
Modifies the Dashboard component to exclude credit card payment transactions ("Inclusao de Pagamento") from all expense calculations while keeping them visible in the transaction list. This ensures that credit card payment transactions don't inflate spending totals in the dashboard statistics.

**Changes made:**
- Added `isPaymentTransaction()` utility function for case-insensitive detection
- Filtered payment transactions from total amount and transaction count calculations
- Excluded payment transactions from category statistics and monthly spending data
- Payment transactions remain visible in the transaction list (no changes to TransactionList component)

## Review & Testing Checklist for Human (4 items)
- [ ] **Test with real C6 Bank XLSX data** containing "Inclusao de Pagamento" transactions to verify filtering works correctly
- [ ] **Verify payment transactions still appear** in the Transactions tab while being excluded from Dashboard calculations
- [ ] **Check Dashboard calculations** show reduced totals when payment transactions are present (compare before/after totals)
- [ ] **Validate string matching** - confirm if C6 Bank uses any other variations of payment transaction descriptions that should be handled

### Recommended Test Plan
1. Load XLSX file with mixed transactions including payment entries
2. Navigate to Dashboard tab and note the total amounts
3. Switch to Transactions tab and confirm payment transactions are visible
4. Cross-check that dashboard totals exclude payment amounts but transaction list includes them

### Notes
- String matching uses case-insensitive detection: `transaction.descricao.toLowerCase().includes('inclusao de pagamento')`
- Multiple filtering operations could be optimized in future iterations by filtering once upfront
- Implementation tested with mock data but requires validation with real C6 Bank data

**Link to Devin run:** https://app.devin.ai/sessions/97d2a8f2653349369e350c4a3d8d586e  
**Requested by:** Felipe C.Z. (@FelipeCZ)